### PR TITLE
Add WASM4 context and memory dump support

### DIFF
--- a/examples/snake_dump.rs
+++ b/examples/snake_dump.rs
@@ -1,0 +1,69 @@
+use std::path::PathBuf;
+use zk_engine::{
+    nova::{
+        provider::{ipa_pc, Bn256EngineIPA},
+        spartan,
+        traits::Dual,
+    },
+    error::ZKWASMError,
+    utils::logging::init_logger,
+    wasm_ctx::{WASMArgsBuilder, Wasm4Ctx, ZKWASMCtx},
+    wasm_snark::{StepSize, WasmSNARK},
+};
+use serde::Serialize;
+
+pub type E = Bn256EngineIPA;
+pub type EE1 = ipa_pc::EvaluationEngine<E>;
+pub type EE2 = ipa_pc::EvaluationEngine<Dual<E>>;
+pub type S1 = spartan::batched::BatchedRelaxedR1CSSNARK<E, EE1>;
+pub type S2 = spartan::batched::BatchedRelaxedR1CSSNARK<Dual<E>, EE2>;
+
+#[derive(Serialize)]
+struct MemoryDump {
+    inputs: String,
+    trace_len: usize,
+    stack_len: usize,
+    mem_len: usize,
+    is_state: Vec<(usize, u64, u64)>,
+}
+
+fn main() -> Result<(), ZKWASMError> {
+    init_logger();
+
+    let step_size = StepSize::new(1000);
+    let inputs = "RRDDLU";
+
+    let wasm_args = WASMArgsBuilder::default()
+        .file_path(PathBuf::from(
+            "third-party/snake-w4-rs/target/wasm32-unknown-unknown/release/snake_w4_rs.wasm",
+        ))?
+        .invoke("update")
+        .func_args(vec![])
+        .step_inputs(inputs.as_bytes().to_vec())
+        .build();
+    let wasm_ctx = Wasm4Ctx::new(wasm_args.clone());
+
+    // Capture execution trace and initial memory state
+    let (trace, is_state, is_sizes) = wasm_ctx.execution_trace()?;
+
+    let dump = MemoryDump {
+        inputs: inputs.to_string(),
+        trace_len: trace.len(),
+        stack_len: is_sizes.stack_len(),
+        mem_len: is_sizes.mem_len(),
+        is_state,
+    };
+
+    std::fs::write(
+        "snake_memory.json",
+        serde_json::to_string_pretty(&dump).expect("serialize"),
+    )
+    .map_err(|e| ZKWASMError::WASMError(e.to_string()))?;
+
+    // Optional: prove and verify the game execution
+    let pp = WasmSNARK::<E, S1, S2>::setup(step_size);
+    let (snark, instance) = WasmSNARK::<E, S1, S2>::prove(&pp, &wasm_ctx, step_size)?;
+    snark.verify(&pp, &instance)?;
+
+    Ok(())
+}

--- a/third-party/snake-w4-rs/src/lib.rs
+++ b/third-party/snake-w4-rs/src/lib.rs
@@ -21,3 +21,47 @@ fn start() {
 fn update() {
     SNAKE_GAME.lock().expect("game_state").update();
 }
+
+#[repr(C)]
+pub struct GameDump {
+    pub score: u32,
+    pub body_len: u32,
+    pub body: [snake::Point; 64],
+    pub fruit: snake::Point,
+}
+
+static mut LAST_DUMP: GameDump = GameDump {
+    score: 0,
+    body_len: 0,
+    body: [snake::Point { x: 0, y: 0 }; 64],
+    fruit: snake::Point { x: 0, y: 0 },
+};
+
+#[no_mangle]
+pub extern "C" fn play_dump(inputs_ptr: *const u8, len: usize) -> *const GameDump {
+    let inputs = unsafe { core::slice::from_raw_parts(inputs_ptr, len) };
+    let mut game = Game::new();
+
+    for &b in inputs {
+        let btn = match b {
+            b'L' => wasm4::BUTTON_LEFT,
+            b'R' => wasm4::BUTTON_RIGHT,
+            b'U' => wasm4::BUTTON_UP,
+            b'D' => wasm4::BUTTON_DOWN,
+            _ => 0,
+        };
+        unsafe { (wasm4::GAMEPAD1 as *mut u8).write(btn) };
+        game.update();
+        unsafe { (wasm4::GAMEPAD1 as *mut u8).write(0) };
+    }
+
+    unsafe {
+        LAST_DUMP.score = game.score;
+        LAST_DUMP.body_len = game.snake.body.len() as u32;
+        for (dst, src) in LAST_DUMP.body.iter_mut().zip(game.snake.body.iter()) {
+            *dst = *src;
+        }
+        LAST_DUMP.fruit = game.fruit;
+        &LAST_DUMP as *const GameDump
+    }
+}


### PR DESCRIPTION
## Summary
- extend `WASMArgs` to include per-step inputs
- implement `Wasm4Ctx` for replaying inputs each frame
- update `snake_dump` example to use `Wasm4Ctx`
- add `play_dump` function to snake WASM to export final game state

## Testing
- `cargo build --quiet`
- `cargo build --example snake_dump --quiet`
- `cargo test --quiet` *(interrupted after long running tests)*